### PR TITLE
Two-layer generic crafting code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ name = "craftlib"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "itertools 0.14.0",
  "pod2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ resolver = "3"
 
 [workspace.dependencies]
 anyhow = "1.0.56"
+itertools = "0.14.0"
 pod2 = { git="https://github.com/0xPARC/pod2", rev = "707c14db14d03485c68045a903771591e533ba59", default-features = false, features = ["backend_plonky2", "disk_cache", "zk"]}

--- a/craftlib/Cargo.toml
+++ b/craftlib/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2024"
 
 [dependencies]
 anyhow = { workspace = true }
+itertools.workspace = true
 pod2 = { workspace = true }

--- a/craftlib/src/constants.rs
+++ b/craftlib/src/constants.rs
@@ -1,4 +1,7 @@
 use std::ops::Range;
 
+use pod2::middleware::{EMPTY_VALUE, RawValue};
+
 pub const COPPER_BLUEPRINT: &str = "copper";
 pub const COPPER_MINING_RANGE: Range<u64> = 0..0x0020_0000_0000_0000;
+pub const COPPER_WORK: RawValue = EMPTY_VALUE;

--- a/craftlib/src/item.rs
+++ b/craftlib/src/item.rs
@@ -2,14 +2,20 @@ use std::{collections::HashSet, ops::Range};
 
 use pod2::{
     dict,
+    frontend::{MainPod, MainPodBuilder, Operation},
     middleware::{
-        Hash, Params, RawValue, ToFields, Value,
+        EMPTY_HASH, EMPTY_VALUE, Hash, MainPodProver, Params, RawValue, Statement, ToFields, VDSet,
+        Value,
         containers::{Dictionary, Set},
         hash_values,
     },
 };
 
-use crate::{predicates::CONSUMED_ITEM_EXTERNAL_NULLIFIER, util::set_from_hashes};
+use crate::{
+    constants::COPPER_BLUEPRINT,
+    predicates::{CONSUMED_ITEM_EXTERNAL_NULLIFIER, CommitPredicates, ItemPredicates},
+    util::set_from_hashes,
+};
 
 // Rust-level definition of the ingredients of an item, used to derive the
 // ingredients hash (dict root) before doing sequential work on it.
@@ -115,20 +121,240 @@ impl MiningRecipe {
     }
 }
 
+// Adds statements to MainPodBilder to represent a generic item based on the
+// ItemDef.  Includes the following public predicates: ItemDef, ItemKey
+// Returns the Statement object for ItemDef for use in further statements.
+fn build_generic_item(
+    builder: &mut MainPodBuilder,
+    item_def: ItemDef,
+    commit_preds: &CommitPredicates,
+    params: &Params,
+) -> anyhow::Result<Statement> {
+    let ingredients_dict = item_def.ingredients.dict(params)?;
+    let inputs_set = item_def.ingredients.inputs_set(params)?;
+    let item_hash = item_def.item_hash(params)?;
+
+    // Build ItemDef(item, ingredients, inputs, key, work)
+    let st_contains_inputs = builder.priv_op(Operation::dict_contains(
+        ingredients_dict.clone(),
+        "inputs",
+        inputs_set.clone(),
+    ))?;
+    let st_contains_key = builder.priv_op(Operation::dict_contains(
+        ingredients_dict.clone(),
+        "key",
+        item_def.ingredients.key,
+    ))?;
+    let st_item_hash = builder.priv_op(Operation::hash_of(
+        item_hash,
+        ingredients_dict.clone(),
+        item_def.work,
+    ))?;
+    let st_item_def = builder.pub_op(Operation::custom(
+        commit_preds.item_def.clone(),
+        [st_contains_inputs, st_contains_key, st_item_hash],
+    ))?;
+
+    // Build ItemKey(item, key)
+    let _st_itemkey = builder.pub_op(Operation::custom(
+        commit_preds.item_key.clone(),
+        [st_item_def.clone()],
+    ))?;
+
+    Ok(st_item_def)
+}
+
+// Adds statements to MainPodBilder to represent Copper as additions to
+// already-existing generic item statements.
+// Builds the following public predicates: IsCopper
+// Returns the Statement object for IsCopper for use in further statements.
+fn build_copper(
+    builder: &mut MainPodBuilder,
+    item_def: ItemDef,
+    st_item_def: Statement,
+    item_preds: &ItemPredicates,
+    params: &Params,
+) -> anyhow::Result<Statement> {
+    // Build IsCopper(item)
+    let st_work_empty = builder.priv_op(Operation::eq(item_def.work, EMPTY_VALUE))?;
+    let st_inputs_eq_empty = builder.priv_op(Operation::eq(
+        item_def.ingredients.inputs_set(params)?,
+        EMPTY_VALUE,
+    ))?;
+    let st_contains_blueprint = builder.priv_op(Operation::dict_contains(
+        item_def.ingredients.dict(params)?,
+        "blueprint",
+        Value::from(COPPER_BLUEPRINT),
+    ))?;
+    let st_is_copper = builder.pub_op(Operation::custom(
+        item_preds.is_copper.clone(),
+        [
+            st_item_def,
+            st_work_empty,
+            st_inputs_eq_empty,
+            st_contains_blueprint,
+        ],
+    ))?;
+
+    Ok(st_is_copper)
+}
+
+// Builds the private POD to store locally for use in further crafting.
+// Contains the following public predicates: ItemDef, ItemKey, IsCopper
+pub fn prove_copper(
+    item_def: ItemDef,
+
+    // TODO: All the args below might belong in a ItemBuilder object
+    commit_preds: &CommitPredicates,
+    item_preds: &ItemPredicates,
+    params: &Params,
+    prover: &dyn MainPodProver,
+    vd_set: &VDSet,
+) -> anyhow::Result<MainPod> {
+    let mut builder = MainPodBuilder::new(&Default::default(), vd_set);
+
+    let st_item_def = build_generic_item(&mut builder, item_def.clone(), commit_preds, params)?;
+    let _st_is_copper = build_copper(&mut builder, item_def, st_item_def, item_preds, params)?;
+
+    // Prove MainPOD
+    Ok(builder.prove(prover)?)
+}
+
+// Adds statements to MainPodBilder to prove inclusion of input_set in
+// created_items_set.  Returns the private SuperSubSet statement.
+fn build_created_items_subset(
+    builder: &mut MainPodBuilder,
+    inputs_set: Set,
+    created_items: Set,
+    commit_preds: &CommitPredicates,
+) -> anyhow::Result<Statement> {
+    // TODO: Needs a real impl.  This only works for 0 inputs.
+    assert!(inputs_set.commitment() == EMPTY_HASH);
+
+    // Build SuperSubSet(created_items, inputs)
+    // We use builder.op() to manually specify the `super` wildcard value
+    // because it's otherwise unconstrained.  This is only relevant in
+    // the base case where `sub` is empty, which is a subset of anything.
+    let st_inputs_eq_empty = builder.priv_op(Operation::eq(inputs_set, EMPTY_VALUE))?;
+    let st_inputs_subset = builder.op(
+        false, /*public*/
+        vec![(0, Value::from(created_items))],
+        Operation::custom(
+            commit_preds.super_sub_set.clone(),
+            [st_inputs_eq_empty.clone(), Statement::None],
+        ),
+    )?;
+
+    Ok(st_inputs_subset)
+}
+
+// Adds statements to MainPodBilder to prove correct nullifiers for a set of
+// inputs.  Returns the private Nullifiers.
+fn build_nullifiers(
+    builder: &mut MainPodBuilder,
+    inputs_set: Set,
+    nullifiers: Set,
+    commit_preds: &CommitPredicates,
+) -> anyhow::Result<Statement> {
+    // TODO: Needs a real impl.  This only works for 0 inputs.
+    assert!(inputs_set.commitment() == EMPTY_HASH);
+    assert!(nullifiers.commitment() == EMPTY_HASH);
+
+    // Build Nullifiers(nullifiers, inputs)
+    let st_inputs_eq_empty = builder.priv_op(Operation::eq(inputs_set, EMPTY_VALUE))?;
+    let st_nullifiers_eq_empty = builder.priv_op(Operation::eq(nullifiers.clone(), EMPTY_VALUE))?;
+    let st_nullifiers_empty = builder.priv_op(Operation::custom(
+        commit_preds.nullifiers_empty.clone(),
+        [st_inputs_eq_empty.clone(), st_nullifiers_eq_empty],
+    ))?;
+    let st_nullifiers = builder.priv_op(Operation::custom(
+        commit_preds.nullifiers.clone(),
+        [st_nullifiers_empty, Statement::None],
+    ))?;
+
+    Ok(st_nullifiers)
+}
+
+// Builds the public POD to commit a crafting operation on-chain, with the only
+// public predicate being CommitCrafting.  Uses a given created_items_set as
+// the root to prove that inputs were previously crafted.
+pub fn prove_commit_crafting(
+    item_def: ItemDef,
+    created_items: Set,
+    item_main_pod: MainPod,
+
+    // TODO: All the args below might belong in a ItemBuilder object
+    commit_preds: &CommitPredicates,
+    params: &Params,
+    prover: &dyn MainPodProver,
+    vd_set: &VDSet,
+) -> anyhow::Result<MainPod> {
+    let mut builder = MainPodBuilder::new(&Default::default(), vd_set);
+
+    // TODO: Consider a more robust lookup for this which doesn't depend on index.
+    let st_item_def = item_main_pod.public_statements[0].clone();
+    builder.add_pod(item_main_pod);
+
+    let st_inputs_subset = build_created_items_subset(
+        &mut builder,
+        item_def.ingredients.inputs_set(params)?,
+        created_items.clone(),
+        commit_preds,
+    )?;
+
+    // TODO: Calculate real nullifiers for non-empty inputs.
+    let nullifiers = set_from_hashes(params, &HashSet::new())?;
+    let st_nullifiers = build_nullifiers(
+        &mut builder,
+        item_def.ingredients.inputs_set(params)?,
+        nullifiers,
+        commit_preds,
+    )?;
+
+    // Build CommitCrafting(item, nullifiers, created_items)
+    let _st_commit_crafting = builder.pub_op(Operation::custom(
+        commit_preds.commit_crafting.clone(),
+        [st_item_def, st_inputs_subset, st_nullifiers],
+    ))?;
+
+    // Prove MainPOD
+    Ok(builder.prove(prover)?)
+}
+
 #[cfg(test)]
 mod tests {
 
-    use pod2::middleware::RawValue;
+    use std::collections::HashMap;
+
+    use pod2::{
+        backends::plonky2::mock::mainpod::MockProver,
+        lang::parse,
+        middleware::{RawValue, hash_value},
+    };
 
     use super::*;
-    use crate::constants::{COPPER_BLUEPRINT, COPPER_MINING_RANGE};
+    use crate::{
+        constants::{COPPER_BLUEPRINT, COPPER_MINING_RANGE, COPPER_WORK},
+        predicates::{CommitPredicates, ItemPredicates},
+        test_util::test::mock_vd_set,
+    };
+
+    // Seed of 2612=0xA34 is a match with hash 6647892930992163=0x000A7EE9D427E832.
+    const COPPER_START_SEED: i64 = 0x9C4;
+    const COPPER_END_SEED: i64 = 0x19C4;
+
+    fn check_matched_wildcards(matched: HashMap<String, Value>, expected: HashMap<String, Value>) {
+        assert_eq!(matched.len(), expected.len(), "len");
+        for name in expected.keys() {
+            assert_eq!(matched[name], expected[name], "{name}");
+        }
+    }
 
     #[test]
     fn test_mine_copper() -> anyhow::Result<()> {
         let params = Params::default();
         let mining_recipe = MiningRecipe::new_no_inputs(COPPER_BLUEPRINT.to_string());
         let key = RawValue::from(0xBADC0DE);
-        let work = RawValue::from(0xDEADBEEF);
 
         let mine_nothing = mining_recipe.do_mining(&params, key, 0..0, COPPER_MINING_RANGE)?;
         assert!(mine_nothing.is_none());
@@ -139,17 +365,167 @@ mod tests {
         // Seed of 2612=0xA34 is a match with hash 6647892930992163=0x000A7EE9D427E832.
         // TODO: This test is going to get slower (~2s) whenever the ingredient
         // dict definition changes.  Need a better approach to testing mining.
-        let mine_success =
-            mining_recipe.do_mining(&params, key, 0x9C4..0x19C4, COPPER_MINING_RANGE)?;
+        let mine_success = mining_recipe.do_mining(
+            &params,
+            key,
+            COPPER_START_SEED..COPPER_END_SEED,
+            COPPER_MINING_RANGE,
+        )?;
         assert!(mine_success.is_some());
 
         let ingredients_def = mine_success.unwrap();
-        let item_def = ItemDef::new(ingredients_def.clone(), work);
+        let item_def = ItemDef::new(ingredients_def.clone(), COPPER_WORK);
         let item_hash = item_def.item_hash(&params)?;
         println!(
             "Mined copper {:?} from ingredients {:?}",
             item_hash,
             ingredients_def.hash(&params)?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mine_and_prove_copper() -> anyhow::Result<()> {
+        let params = Params::default();
+        let commit_preds = CommitPredicates::compile(&params);
+        let item_preds = ItemPredicates::compile(&params, &commit_preds);
+
+        let prover = &MockProver {};
+        let vd_set = &mock_vd_set();
+
+        // Mine copper with a selected key.
+        let key = RawValue::from(0xBADC0DE);
+        let mining_recipe = MiningRecipe::new_no_inputs(COPPER_BLUEPRINT.to_string());
+        let ingredients_def = mining_recipe
+            .do_mining(
+                &params,
+                key,
+                COPPER_START_SEED..COPPER_END_SEED,
+                COPPER_MINING_RANGE,
+            )?
+            .unwrap();
+
+        // Pre-calculate hashes and intermediate values.
+        let ingredients_dict = ingredients_def.dict(&params)?;
+        let inputs_set = ingredients_def.inputs_set(&params)?;
+        let item_def = ItemDef {
+            ingredients: ingredients_def.clone(),
+            work: COPPER_WORK,
+        };
+        let item_hash = item_def.item_hash(&params)?;
+
+        // Prove a copper POD.  This is the private POD for the player to store
+        // locally for future crafting.
+        let copper_main_pod = prove_copper(
+            item_def.clone(),
+            &commit_preds,
+            &item_preds,
+            &params,
+            prover,
+            vd_set,
+        )?;
+
+        copper_main_pod.pod.verify()?;
+        assert_eq!(copper_main_pod.public_statements.len(), 3);
+        //println!("Copper POD: {:?}", copper_main_pod.pod);
+
+        // PODLang query to check the final statements.
+        let copper_query = format!(
+            r#"
+            {}
+            {}
+
+            REQUEST(
+                ItemDef(item, ingredients, inputs, key, work)
+                ItemKey(item, key)
+                IsCopper(item)
+            )
+            "#,
+            &commit_preds.defs.imports, &item_preds.defs.imports,
+        );
+
+        println!("Copper verification request: {copper_query}");
+
+        let copper_request = parse(
+            &copper_query,
+            &params,
+            &[
+                commit_preds.defs.batches.clone(),
+                item_preds.defs.batches.clone(),
+            ]
+            .concat(),
+        )?
+        .request;
+        let matched_wildcards = copper_request.exact_match_pod(&*copper_main_pod.pod)?;
+        check_matched_wildcards(
+            matched_wildcards,
+            HashMap::from([
+                ("item".to_string(), Value::from(item_hash)),
+                ("ingredients".to_string(), Value::from(ingredients_dict)),
+                ("inputs".to_string(), Value::from(inputs_set)),
+                ("key".to_string(), Value::from(key)),
+                ("work".to_string(), Value::from(EMPTY_VALUE)),
+            ]),
+        );
+
+        // Dummy (non-empty) created items set which works for 0 inputs.
+        let created_items = set_from_hashes(
+            &params,
+            &HashSet::from([
+                hash_value(&Value::from("dummy1").raw()),
+                hash_value(&Value::from("dummy2").raw()),
+            ]),
+        )?;
+
+        // TODO Prove a commitment POD to send on-chain.  This intentionally doesn't
+        // expose any public statements other than CommitCrafting.
+        let commit_main_pod = prove_commit_crafting(
+            item_def,
+            created_items.clone(),
+            copper_main_pod,
+            &commit_preds,
+            &params,
+            prover,
+            vd_set,
+        )?;
+
+        commit_main_pod.pod.verify()?;
+        assert_eq!(commit_main_pod.public_statements.len(), 1);
+        //println!("Commit POD: {:?}", copper_main_pod.pod);
+
+        // PODLang query to check the final statement.
+        let commit_query = format!(
+            r#"
+            {}
+
+            REQUEST(
+                CommitCrafting(item, nullifiers, created_items)
+            )
+            "#,
+            &commit_preds.defs.imports,
+        );
+
+        println!("Commit verification request: {commit_query}");
+
+        let commit_request = parse(
+            &commit_query,
+            &params,
+            &[
+                commit_preds.defs.batches.clone(),
+                item_preds.defs.batches.clone(),
+            ]
+            .concat(),
+        )?
+        .request;
+        let matched_wildcards = commit_request.exact_match_pod(&*commit_main_pod.pod)?;
+        check_matched_wildcards(
+            matched_wildcards,
+            HashMap::from([
+                ("item".to_string(), Value::from(item_hash)),
+                ("created_items".to_string(), Value::from(created_items)),
+                ("nullifiers".to_string(), Value::from(EMPTY_VALUE)),
+            ]),
         );
 
         Ok(())

--- a/craftlib/src/lib.rs
+++ b/craftlib/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod constants;
 pub mod item;
 pub mod predicates;
+mod test_util;
 pub mod util;

--- a/craftlib/src/predicates.rs
+++ b/craftlib/src/predicates.rs
@@ -1,11 +1,77 @@
 use std::{slice, sync::Arc};
 
-use pod2::middleware::{CustomPredicateBatch, CustomPredicateRef, Params};
+use itertools::Itertools;
+use pod2::middleware::{CustomPredicateBatch, CustomPredicateRef, Hash, Params};
 
 pub const CONSUMED_ITEM_EXTERNAL_NULLIFIER: &str = "consumed item external nullifier";
 
-pub struct CraftingPredicates {
+// Generic data-drive struct for holidng a set of custom predicates built from
+// 1 or more batches.
+pub struct PredicateDefs {
     pub batches: Vec<Arc<CustomPredicateBatch>>,
+    pub batch_ids: Vec<Hash>,
+    pub imports: String,
+}
+
+impl PredicateDefs {
+    // Builds the imports and by_name fields automatically from an array batch
+    // code in PODLang.  Later batches will import previous batches automatically,
+    // while use statements for external batches can be included using
+    // external_batches.
+    // This is meant for use on constant PODLang definitions, so it panics on
+    // errors.
+    pub fn new(params: &Params, batch_code: &[&str], external_defs: &[PredicateDefs]) -> Self {
+        let external_imports = external_defs.iter().map(|d| d.imports.clone()).join("\n");
+        let external_batches = external_defs.iter().map(|d| d.batches.clone()).concat();
+
+        let mut batches = Vec::<Arc<CustomPredicateBatch>>::new();
+        let mut imports = String::new();
+
+        for podlang_code in batch_code {
+            let batch = pod2::lang::parse(
+                &format!(
+                    "{}\n{}\n{}",
+                    external_imports,
+                    imports.clone(),
+                    podlang_code
+                ),
+                params,
+                &[external_batches.clone(), batches.clone()].concat(),
+            )
+            .unwrap()
+            .custom_batch;
+
+            imports += &format!(
+                "use batch {} from {:#}\n",
+                batch.predicates().iter().map(|p| p.name.clone()).join(", "),
+                batch.id()
+            );
+
+            batches.push(batch);
+        }
+
+        PredicateDefs {
+            batch_ids: batches.clone().iter().map(|b| b.id()).collect(),
+            batches,
+            imports,
+        }
+    }
+
+    // Finds a predicate by name in any of the included batches.
+    pub fn predicate_ref_by_name(&self, pred_name: &str) -> Option<CustomPredicateRef> {
+        for batch in self.batches.iter() {
+            let found = CustomPredicateBatch::predicate_ref_by_name(batch, pred_name);
+            if found.is_some() {
+                return found;
+            }
+        }
+
+        None
+    }
+}
+
+pub struct CommitPredicates {
+    pub defs: PredicateDefs,
 
     pub super_sub_set: CustomPredicateRef,
     pub super_sub_set_recursive: CustomPredicateRef,
@@ -16,162 +82,136 @@ pub struct CraftingPredicates {
     pub nullifiers_empty: CustomPredicateRef,
     pub nullifiers_recursive: CustomPredicateRef,
     pub commit_crafting: CustomPredicateRef,
+}
+
+impl CommitPredicates {
+    pub fn compile(params: &Params) -> Self {
+        // maximum allowed:
+        // 4 batches
+        // 4 predicates per batch
+        // 8 arguments per predicate, at most 5 of which are public
+        // 5 statements per predicate
+        let batch_defs = [
+            r#"
+            // Generic recursive construction confirming subset.  Relies on the Merkle
+            // tree already requiring unique keys (so no inserts on super)
+            SuperSubSet(super, sub) = OR(
+                Equal(sub, {})
+                SuperSubSetRecursive(super, sub)
+            )
+
+            SuperSubSetRecursive(super, sub, private: i, smaller) = AND(
+                SetContains(super, i)
+                SetInsert(sub, smaller, i)
+                SuperSubSet(super, smaller)
+            )
+
+            // Prove proper derivation of item ID from defined inputs
+            // The ingredients dict is explicitly allowed to contain more fields
+            // for use in item predicates.
+            ItemDef(item, ingredients, inputs, key, work) = AND(
+                DictContains(ingredients, "inputs", inputs)
+                DictContains(ingredients, "key", key)
+                HashOf(item, ingredients, work)
+            )
+
+            // Helper to expose just the item and key from ItemId calculation.
+            // This is just the CraftedItem pattern with some of inupts private.
+            ItemKey(item, key, private: ingredients, inputs, work) = AND(
+                ItemDef(item, ingredients, inputs, key, work)
+            )
+            "#,
+            r#"
+            // Derive nullifiers from items (using a recursive foreach construction)
+            // This proves the relationship between an item and its key before using
+            // the key to calculate a nullifier.
+            Nullifiers(nullifiers, inputs) = OR(
+                NullifiersEmpty(nullifiers, inputs)
+                NullifiersRecursive(nullifiers, inputs)
+            )
+
+            NullifiersEmpty(nullifiers, inputs) = AND(
+                Equal(nullifiers, {})
+                Equal(inputs, {})
+            )
+
+            NullifiersRecursive(nullifiers, inputs, private: i, n, k, ns, is) = AND(
+                ItemKey(i, k)
+                HashOf(n, k, "consumed item external nullifier")
+                SetInsert(nullifiers, ns, n)
+                SetInsert(inputs, is, i)
+                Nullifiers(ns, is)
+            )
+
+            // ZK version of CraftedItem for committing on-chain.
+            // Validator/Logger/Archiver needs to maintain 2 append-only
+            // sets of items and nullifiers.  New crafting is
+            // accepted iff:
+            // - item is not already in item set
+            // - all nullifiers are not already in nullifier set
+            // - createdItems is one of the historical item set roots
+            CommitCrafting(item, nullifiers, created_items, private: ingredients, inputs, key, work) = AND(
+                // Prove the item hash includes all of its committed properties
+                ItemDef(item, ingredients, inputs, key, work)
+
+                // Prove all inputs are in the created set
+                SuperSubSet(created_items, inputs)
+
+                // Expose nullifiers for all inputs
+                Nullifiers(nullifiers, inputs)
+            )
+            "#,
+        ];
+
+        let defs = PredicateDefs::new(params, &batch_defs, &[]);
+
+        CommitPredicates {
+            super_sub_set: defs.predicate_ref_by_name("SuperSubSet").unwrap(),
+            super_sub_set_recursive: defs.predicate_ref_by_name("SuperSubSetRecursive").unwrap(),
+            item_def: defs.predicate_ref_by_name("ItemDef").unwrap(),
+            item_key: defs.predicate_ref_by_name("ItemKey").unwrap(),
+            nullifiers: defs.predicate_ref_by_name("Nullifiers").unwrap(),
+            nullifiers_empty: defs.predicate_ref_by_name("NullifiersEmpty").unwrap(),
+            nullifiers_recursive: defs.predicate_ref_by_name("NullifiersRecursive").unwrap(),
+            commit_crafting: defs.predicate_ref_by_name("CommitCrafting").unwrap(),
+            defs,
+        }
+    }
+}
+
+pub struct ItemPredicates {
+    pub defs: PredicateDefs,
 
     pub is_copper: CustomPredicateRef,
 }
 
-pub fn custom_predicates() -> CraftingPredicates {
-    // maximum allowed:
-    // 4 batches
-    // 4 predicates per batch
-    // 8 arguments per predicate, at most 5 of which are public
-    // 5 statements per predicate
-    let params = Params::default();
-    let batch0 = pod2::lang::parse(
-        r#"
-        // Generic recursive construction confirming subset.  Relies on the Merkle
-        // tree already requiring unique keys (so no inserts on super)
-        SuperSubSet(super, sub) = OR(
-            Equal(sub, {})
-            SuperSubSetRecursive(super, sub)
-        )
+impl ItemPredicates {
+    pub fn compile(params: &Params, commit_preds: &CommitPredicates) -> Self {
+        // maximum allowed:
+        // 4 batches
+        // 4 predicates per batch
+        // 8 arguments per predicate, at most 5 of which are public
+        // 5 statements per predicate
+        let batch_defs = [r#"
+            // Example of a mined item with no inputs or sequential work.
+            // Copper requ`ires working in a copper mine (blueprint="copper") and
+            // 10 leading 0s.
+            IsCopper(item, private: ingredients, inputs, key, work) = AND(
+                ItemDef(item, ingredients, inputs, key, work)
+                Equal(inputs, {})
+                Equal(work, 0)
+                DictContains(ingredients, "blueprint", "copper")
 
-        SuperSubSetRecursive(super, sub, private: i, smaller) = AND(
-            SetContains(super, i)
-            SetInsert(sub, smaller, i)
-            SuperSubSet(super, smaller)
-        )
+                // TODO input POD: HashInRange(0, 1<<10, ingredients)
+            )
+            "#];
 
-        // Prove proper derivation of item ID from defined inputs
-        // The ingredients dict is explicitly allowed to contain more fields
-        // for use in item predicates.
-        ItemDef(item, ingredients, inputs, key, work) = AND(
-            DictContains(ingredients, "inputs", inputs)
-            DictContains(ingredients, "key", key)
-            HashOf(item, ingredients, work)
-        )
+        let defs = PredicateDefs::new(params, &batch_defs, slice::from_ref(&commit_preds.defs));
 
-        // Helper to expose just the item and key from ItemId calculation.
-        // This is just the CraftedItem pattern with some of inupts private.
-        ItemKey(item, key, private: ingredients, inputs, work) = AND(
-            ItemDef(item, ingredients, inputs, key, work)
-        )
-        "#,
-        &params,
-        &[],
-    )
-    .unwrap()
-    .custom_batch;
-    let super_sub_set =
-        CustomPredicateBatch::predicate_ref_by_name(&batch0, "SuperSubSet").unwrap();
-    let super_sub_set_recursive =
-        CustomPredicateBatch::predicate_ref_by_name(&batch0, "SuperSubSetRecursive").unwrap();
-    let item_def = CustomPredicateBatch::predicate_ref_by_name(&batch0, "ItemDef").unwrap();
-    let item_key = CustomPredicateBatch::predicate_ref_by_name(&batch0, "ItemKey").unwrap();
-
-    let batch1 = pod2::lang::parse(
-        &format!(
-            r#"
-        use batch SuperSubSet, _, ItemDef, ItemKey from {:#}
-
-        // Derive nullifiers from items (using a recursive foreach construction)
-        // This proves the relationship between an item and its key before using
-        // the key to calculate a nullifier.
-        Nullifiers(nullifiers, inputs) = OR(
-            NullifiersEmpty(nullifiers, inputs)
-            NullifiersRecursive(nullifiers, inputs)
-        )
-
-        NullifiersEmpty(nullifiers, inputs) = AND(
-            Equal(nullifiers, {{}})
-            Equal(inputs, {{}})
-        )
-
-        NullifiersRecursive(nullifiers, inputs, private: i, n, k, ns, is) = AND(
-            ItemKey(i, k)
-            HashOf(n, k, "consumed item external nullifier")
-            SetInsert(nullifiers, ns, n)
-            SetInsert(inputs, is, i)
-            Nullifiers(ns, is)
-        )
-
-        // ZK version of CraftedItem for committing on-chain.
-        // Validator/Logger/Archiver needs to maintain 2 append-only
-        // sets of items and nullifiers.  New crafting is
-        // accepted iff:
-        // - item is not already in item set
-        // - all nullifiers are not already in nullifier set
-        // - createdItems is one of the historical item set roots
-        CommitCrafting(item, nullifiers, created_items, private: ingredients, inputs, key, work) = AND(
-            // Prove the item hash includes all of its committed properties
-            ItemDef(item, ingredients, inputs, key, work)
-
-            // Prove all inputs are in the created set
-            SuperSubSet(created_items, inputs)
-
-            // Expose nullifiers for all inputs
-            Nullifiers(nullifiers, inputs)
-        )
-
-        "#,
-            &batch0.id()
-        ),
-        &params,
-        slice::from_ref(&batch0),
-    )
-    .unwrap()
-    .custom_batch;
-
-    let nullifiers = CustomPredicateBatch::predicate_ref_by_name(&batch1, "Nullifiers").unwrap();
-    let nullifiers_empty =
-        CustomPredicateBatch::predicate_ref_by_name(&batch1, "NullifiersEmpty").unwrap();
-    let nullifiers_recursive =
-        CustomPredicateBatch::predicate_ref_by_name(&batch1, "NullifiersRecursive").unwrap();
-    let commit_crafting =
-        CustomPredicateBatch::predicate_ref_by_name(&batch1, "CommitCrafting").unwrap();
-
-    let batch2 = pod2::lang::parse(
-        &format!(
-            r#"
-        use batch SuperSubSet, _, ItemDef, ItemKey from {:#}
-        use batch Nullifiers, _, _, _ from {:#}
-
-
-        // Example of a mined item with no inputs or sequential work.
-        // Copper requires working in a copper mine (blueprint="copper") and
-        // 10 leading 0s.
-        IsCopper(item, private: ingredients, inputs, key, work) = AND(
-            ItemDef(item, ingredients, inputs, key, work)
-            Equal(inputs, {{}})
-            DictContains(ingredients, "blueprint", "copper")
-            // TODO input POD: HashInRange(0, 1<<10, ingredients)
-        )
-        "#,
-            &batch0.id(),
-            &batch1.id()
-        ),
-        &params,
-        &[batch0.clone(), batch1.clone()],
-    )
-    .unwrap()
-    .custom_batch;
-
-    let is_copper = CustomPredicateBatch::predicate_ref_by_name(&batch2, "IsCopper").unwrap();
-
-    CraftingPredicates {
-        batches: vec![batch0, batch1, batch2],
-
-        super_sub_set,
-        super_sub_set_recursive,
-        item_def,
-
-        item_key,
-        nullifiers,
-        nullifiers_empty,
-        nullifiers_recursive,
-
-        commit_crafting,
-        is_copper,
+        ItemPredicates {
+            is_copper: defs.predicate_ref_by_name("IsCopper").unwrap(),
+            defs,
+        }
     }
 }
 
@@ -183,44 +223,39 @@ mod tests {
         backends::plonky2::mock::mainpod::MockProver,
         frontend::{MainPodBuilder, Operation},
         lang::parse,
-        middleware::{EMPTY_VALUE, RawValue, Statement, VDSet, Value, hash_value},
+        middleware::{EMPTY_VALUE, RawValue, Statement, Value, hash_value},
     };
 
     use super::*;
     use crate::{
         constants::COPPER_BLUEPRINT,
         item::{IngredientsDef, ItemDef},
+        test_util::test::{check_matched_wildcards, mock_vd_set},
         util::set_from_hashes,
     };
 
-    fn mock_vd_set() -> VDSet {
-        VDSet::new(6, &[]).unwrap()
-    }
-
-    fn check_matched_wildcards(matched: HashMap<String, Value>, expected: HashMap<String, Value>) {
-        assert_eq!(matched.len(), expected.len(), "len");
-        for name in expected.keys() {
-            assert_eq!(matched[name], expected[name], "{name}");
-        }
-    }
-
     #[test]
     fn test_compile_custom_predicates() {
-        let preds = custom_predicates();
-        assert!(preds.batches.len() == 3);
+        let params = Params::default();
+        let commit_preds = CommitPredicates::compile(&params);
+        assert!(commit_preds.defs.batches.len() == 2);
+
+        let item_preds = ItemPredicates::compile(&params, &commit_preds);
+        assert!(item_preds.defs.batches.len() == 1);
     }
 
     #[test]
     fn test_build_pod_no_inputs() -> anyhow::Result<()> {
-        let preds = custom_predicates();
         let params = Params::default();
+        let commit_preds = CommitPredicates::compile(&params);
+        let item_preds = ItemPredicates::compile(&params, &commit_preds);
 
         let mut builder = MainPodBuilder::new(&Default::default(), &mock_vd_set());
 
         // Item recipe constants
         let seed = 0xA34;
         let key = 0xBADC0DE;
-        let work = 0xDEADBEEF;
+        let work: RawValue = EMPTY_VALUE;
         // TODO: Real mining and sequential work.
 
         // Pre-calculate hashes and intermediate values.
@@ -234,7 +269,7 @@ mod tests {
         let inputs_set = ingredients_def.inputs_set(&params)?;
         let item_def = ItemDef {
             ingredients: ingredients_def.clone(),
-            work: RawValue::from(work),
+            work,
         };
         let item_hash = item_def.item_hash(&params)?;
 
@@ -265,13 +300,13 @@ mod tests {
             item_def.work,
         ))?;
         let st_item_def = builder.pub_op(Operation::custom(
-            preds.item_def.clone(),
+            commit_preds.item_def.clone(),
             [st_contains_inputs, st_contains_key, st_item_hash],
         ))?;
 
         // Build ItemKey(item, key)
         let _st_itemkey = builder.pub_op(Operation::custom(
-            preds.item_key.clone(),
+            commit_preds.item_key.clone(),
             [st_item_def.clone()],
         ))?;
 
@@ -284,7 +319,7 @@ mod tests {
             true, /*public*/
             vec![(0, Value::from(created_items.clone()))],
             Operation::custom(
-                preds.super_sub_set.clone(),
+                commit_preds.super_sub_set.clone(),
                 [st_inputs_eq_empty.clone(), Statement::None],
             ),
         )?;
@@ -293,29 +328,35 @@ mod tests {
         let st_nullifiers_eq_empty =
             builder.priv_op(Operation::eq(nullifiers.clone(), EMPTY_VALUE))?;
         let st_nullifiers_empty = builder.pub_op(Operation::custom(
-            preds.nullifiers_empty.clone(),
+            commit_preds.nullifiers_empty.clone(),
             [st_inputs_eq_empty.clone(), st_nullifiers_eq_empty],
         ))?;
         let st_nullifiers = builder.pub_op(Operation::custom(
-            preds.nullifiers.clone(),
+            commit_preds.nullifiers.clone(),
             [st_nullifiers_empty, Statement::None],
         ))?;
 
         // Build CommitCrafting(item, nullifiers, created_items)
         let _st_commit_crafting = builder.pub_op(Operation::custom(
-            preds.commit_crafting.clone(),
+            commit_preds.commit_crafting.clone(),
             [st_item_def.clone(), st_inputs_subset, st_nullifiers],
         ))?;
 
         // Build IsCopper(item)
+        let st_work_empty = builder.priv_op(Operation::eq(work, EMPTY_VALUE))?;
         let st_contains_blueprint = builder.priv_op(Operation::dict_contains(
             ingredients_dict.clone(),
             "blueprint",
             Value::from(COPPER_BLUEPRINT),
         ))?;
         let _st_is_copper = builder.pub_op(Operation::custom(
-            preds.is_copper.clone(),
-            [st_item_def, st_inputs_eq_empty, st_contains_blueprint],
+            item_preds.is_copper.clone(),
+            [
+                st_item_def,
+                st_inputs_eq_empty,
+                st_work_empty,
+                st_contains_blueprint,
+            ],
         ))?;
 
         // Prove MainPOD
@@ -328,9 +369,8 @@ mod tests {
         // all the values.
         let query = format!(
             r#"
-            use batch SuperSubSet, _, ItemDef, ItemKey from {:#}
-            use batch Nullifiers, _, _, CommitCrafting from {:#}
-            use batch IsCopper from {:#}
+            {}
+            {}
 
             REQUEST(
                 ItemDef(item, ingredients, inputs, key, work)
@@ -341,14 +381,17 @@ mod tests {
                 IsCopper(item)
             )
             "#,
-            &preds.batches[0].id(),
-            &preds.batches[1].id(),
-            &preds.batches[2].id(),
+            &commit_preds.defs.imports, &item_preds.defs.imports,
         );
 
         println!("Verification request: {query}");
 
-        let request = parse(&query, &params, &preds.batches)?.request;
+        let request = parse(
+            &query,
+            &params,
+            &[commit_preds.defs.batches, item_preds.defs.batches].concat(),
+        )?
+        .request;
         let matched_wildcards = request.exact_match_pod(&*main_pod.pod)?;
         check_matched_wildcards(
             matched_wildcards,

--- a/craftlib/src/test_util.rs
+++ b/craftlib/src/test_util.rs
@@ -1,0 +1,21 @@
+#[cfg(test)]
+pub mod test {
+
+    use std::collections::HashMap;
+
+    use pod2::middleware::{VDSet, Value};
+
+    pub fn mock_vd_set() -> VDSet {
+        VDSet::new(6, &[]).unwrap()
+    }
+
+    pub fn check_matched_wildcards(
+        matched: HashMap<String, Value>,
+        expected: HashMap<String, Value>,
+    ) {
+        assert_eq!(matched.len(), expected.len(), "len");
+        for name in expected.keys() {
+            assert_eq!(matched[name], expected[name], "{name}");
+        }
+    }
+}


### PR DESCRIPTION
Refactored the code for building predicates, and for building item PODs to make them more genericly reusable, and to respect the separation between the commit layer, and the app/item layer.

- Predicates are now built in a more data-driven way, and stored in separate structs for CommitPredicates and ItemPredicates.
- Functions in item.rs build the statements and PODs needed for any item based on its ItemDef in reusable way, as well as the specific one for Copper.
- The test in item.rs exercises these new functions to prove 2 separate PODs: one POD has predicates the user can save fur future crafting, while one has only the CommitCrafting predicate to send onchain.

Note1: The biggest limitation here is that I haven't yet implemented code to deal with non-empty input sets, which will require more complicated statement building, as well as more recursive input PODs.  There are TODOs in the code to point out where pieces are missing.  The ItemKey statement is included in the item POD so that it can be fed forward into nullifier calculations.

Note2: I also updated the pod2 reference to the branch for PR438 so I could test the new way of specifying wildcards.  That reference should be updated once that PR lands in main, before this PR lands.  I didn't depend on Edu's experimental macros, though I look forward to them.
