### PR TITLE
add steps to run a local testnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 tmp
 *.pprof
 predicates.md
+kurtosis
+scripts

--- a/README.md
+++ b/README.md
@@ -35,3 +35,48 @@ Start the gui app and begin crafting, committing, vieweing and verifying items
 ```
 RUST_LOG=gui_app=debug,info cargo run --release -p gui_app
 ```
+
+### Running a local testnet:
+
+#### Install 
+
+Requires docker.
+
+linux specific:
+```
+wget 'https://github.com/kurtosis-tech/kurtosis-cli-release-artifacts/releases/download/1.12.1/kurtosis-cli_1.12.1_linux_amd64.tar.gz'
+tar xf kurtosis-cli_1.12.1_linux_amd64.tar.gz
+```
+
+MacOS specific:
+```
+brew install kurtosis-tech/tap/kurtosis-cli
+```
+
+#### Start
+```
+./kurtosis analytics disable
+./kurtosis --enclave local-testnet run github.com/ethpandaops/ethereum-package@b0f4fabf9d2958d7b67e56a2e0dc91ef26c2dd9a --args-file network.yml
+```
+
+Find the CL and EL rpc ports with:
+```
+./kurtosis enclave inspect local-testnet | grep " http: 4000" # BEACON_URL (XXX)
+./kurtosis enclave inspect local-testnet | grep " rpc: 8545" # RPC_URL (YYY)
+```
+
+Use this template for the `.env` and replace the `BEACON_URL` and `RPC_URL` pots for the correct ones:
+```
+# Local testnet
+BEACON_URL="http://127.0.0.1:XXX"
+RPC_URL="http://127.0.0.1:YYY"
+REQUEST_RATE="0"
+# Address = 0x8943545177806ED17B9F23F0a21ee5948eCaa776 (first pre_funded_accounts)
+PRIV_KEY="bcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
+DO_GENESIS_SLOT="0"
+```
+
+#### Stop
+```
+kurtosis enclave rm -f local-testnet
+```

--- a/network.yml
+++ b/network.yml
@@ -1,0 +1,9 @@
+# Configuration file for setting up a local testnet with kurtosis
+participants:
+  - cl_type: lighthouse
+    cl_image: sigp/lighthouse:v8.0.0
+    el_type: geth
+    el_image: ethereum/client-go:v1.16.7
+    supernode: true
+network_params:
+  fulu_fork_epoch: 0


### PR DESCRIPTION
Steps and configuration to run a local testet.  Tested to work on linux so far.
The synchronizer and app work as expected with this.

This will allow us to run the demo in a more reliable way.