### PR TITLE
feat: add proof of work pod

### DIFF
--- a/app_cli/src/lib.rs
+++ b/app_cli/src/lib.rs
@@ -19,7 +19,7 @@ use craftlib::{
         WOOD_MINING_MAX, WOOD_WORK, WOODEN_AXE_BLUEPRINT, WOODEN_AXE_MINING_MAX, WOODEN_AXE_WORK,
     },
     item::{CraftBuilder, MiningRecipe},
-    powpod::PoWPod,
+    powpod::PowPod,
     predicates::ItemPredicates,
     vdfpod::VdfPod,
 };
@@ -182,7 +182,7 @@ impl Helper {
         item_def: ItemDef,
         input_item_pods: Vec<MainPod>,
         vdf_pod: Option<VdfPod>,
-        pow_pod: Option<PoWPod>,
+        pow_pod: Option<PowPod>,
     ) -> anyhow::Result<MainPod> {
         let prover = &Prover {};
         let mut builder = MainPodBuilder::new(&self.params, &self.vd_set);
@@ -351,13 +351,13 @@ pub fn craft_item(
                 .unwrap();
 
             let start = std::time::Instant::now();
-            let pow_pod = PoWPod::new(
+            let pow_pod = PowPod::new(
                 params,
                 vd_set.clone(),
                 RawValue::from(ingredients_def.dict(params)?.commitment()),
                 STONE_MINING_MAX,
             )?;
-            log::info!("[TIME] PoWPod proving time: {:?}", start.elapsed());
+            log::info!("[TIME] PowPod proving time: {:?}", start.elapsed());
 
             let start = std::time::Instant::now();
             let vdf_pod = VdfPod::new(
@@ -387,13 +387,13 @@ pub fn craft_item(
                 .unwrap();
 
             let start = std::time::Instant::now();
-            let pow_pod = PoWPod::new(
+            let pow_pod = PowPod::new(
                 params,
                 vd_set.clone(),
                 RawValue::from(ingredients_def.dict(params)?.commitment()),
                 WOOD_MINING_MAX,
             )?;
-            log::info!("[TIME] PoWPod proving time: {:?}", start.elapsed());
+            log::info!("[TIME] PowPod proving time: {:?}", start.elapsed());
             (
                 ItemDef {
                     ingredients: ingredients_def.clone(),
@@ -419,13 +419,13 @@ pub fn craft_item(
                 .unwrap();
 
             let start = std::time::Instant::now();
-            let pow_pod = PoWPod::new(
+            let pow_pod = PowPod::new(
                 params,
                 vd_set.clone(),
                 RawValue::from(ingredients_def.dict(params)?.commitment()),
                 AXE_MINING_MAX,
             )?;
-            log::info!("[TIME] PoWPod proving time: {:?}", start.elapsed());
+            log::info!("[TIME] PowPod proving time: {:?}", start.elapsed());
             (
                 ItemDef {
                     ingredients: ingredients_def.clone(),

--- a/app_cli/src/lib.rs
+++ b/app_cli/src/lib.rs
@@ -21,6 +21,7 @@ use craftlib::{
     item::{CraftBuilder, MiningRecipe},
     predicates::ItemPredicates,
     vdfpod::VdfPod,
+    powpod::PoWPod,
 };
 use plonky2::field::types::Field;
 use pod2::{
@@ -181,6 +182,7 @@ impl Helper {
         item_def: ItemDef,
         input_item_pods: Vec<MainPod>,
         vdf_pod: Option<VdfPod>,
+        pow_pod: Option<PoWPod>,
     ) -> anyhow::Result<MainPod> {
         let prover = &Prover {};
         let mut builder = MainPodBuilder::new(&self.params, &self.vd_set);
@@ -240,7 +242,18 @@ impl Helper {
                 craft_builder.ctx.builder.add_pod(main_vdf_pod);
                 craft_builder.st_is_stone(item_def, st_item_def.clone(), st_vdf)?
             }
-            Recipe::Wood => craft_builder.st_is_wood(item_def, st_item_def.clone())?,
+            Recipe::Wood => {
+                // unwrap safe since if we're at Wood, pow_pod is Some
+                let pow_pod = pow_pod.unwrap();
+                let st_pow = pow_pod.pub_statements()[0].clone();
+                let main_pow_pod = MainPod {
+                    pod: Box::new(pow_pod.clone()),
+                    public_statements: pow_pod.pub_statements(),
+                    params: craft_builder.params.clone(),
+                };
+                craft_builder.ctx.builder.add_pod(main_pow_pod);
+                craft_builder.st_is_wood(item_def, st_item_def.clone(), st_pow)?
+            }
             Recipe::Axe => craft_builder.st_is_axe(
                 item_def,
                 st_item_def.clone(),
@@ -306,7 +319,7 @@ pub fn craft_item(
     let vd_set = DEFAULT_VD_SET.clone();
     let key = rand_raw_value();
     info!("About to craft \"{recipe}\" with key {key:#}");
-    let (item_def, input_items, vdf_pod) = match recipe {
+    let (item_def, input_items, vdf_pod, pow_pod) = match recipe {
         Recipe::Stone => {
             if !inputs.is_empty() {
                 bail!("{recipe} takes 0 inputs");
@@ -331,6 +344,7 @@ pub fn craft_item(
                 },
                 vec![],
                 Some(vdf_pod),
+                None,
             )
         }
         Recipe::Wood => {
@@ -341,6 +355,15 @@ pub fn craft_item(
             let ingredients_def = mining_recipe
                 .do_mining(params, key, 0, WOOD_MINING_MAX)?
                 .unwrap();
+
+            let start = std::time::Instant::now();
+            let pow_pod = PoWPod::new(
+                params,
+                vd_set.clone(),
+                RawValue::from(ingredients_def.dict(params)?.commitment()),
+                WOOD_MINING_MAX,
+            )?;
+            log::info!("[TIME] PoWPod proving time: {:?}", start.elapsed());
             (
                 ItemDef {
                     ingredients: ingredients_def.clone(),
@@ -348,6 +371,7 @@ pub fn craft_item(
                 },
                 vec![],
                 None,
+                Some(pow_pod),
             )
         }
         Recipe::Axe => {
@@ -369,6 +393,7 @@ pub fn craft_item(
                     work: AXE_WORK,
                 },
                 vec![wood, stone],
+                None,
                 None,
             )
         }
@@ -392,13 +417,14 @@ pub fn craft_item(
                 },
                 vec![wood1, wood2],
                 None,
+                None,
             )
         }
     };
 
     let helper = Helper::new(params.clone(), vd_set);
     let input_item_pods: Vec<_> = input_items.iter().map(|item| &item.pod).cloned().collect();
-    let pod = helper.make_item_pod(recipe, item_def.clone(), input_item_pods, vdf_pod)?;
+    let pod = helper.make_item_pod(recipe, item_def.clone(), input_item_pods, vdf_pod, pow_pod)?;
 
     let crafted_item = CraftedItem { pod, def: item_def };
     let mut file = std::fs::File::create(output)?;

--- a/app_cli/src/lib.rs
+++ b/app_cli/src/lib.rs
@@ -19,8 +19,8 @@ use craftlib::{
         WOOD_MINING_MAX, WOOD_WORK, WOODEN_AXE_BLUEPRINT, WOODEN_AXE_MINING_MAX, WOODEN_AXE_WORK,
     },
     item::{CraftBuilder, MiningRecipe},
-    powpod::PowPod,
     predicates::ItemPredicates,
+    vdfpod::VdfPod,
 };
 use plonky2::field::types::Field;
 use pod2::{
@@ -180,7 +180,7 @@ impl Helper {
         recipe: Recipe,
         item_def: ItemDef,
         input_item_pods: Vec<MainPod>,
-        pow_pod: Option<PowPod>,
+        vdf_pod: Option<VdfPod>,
     ) -> anyhow::Result<MainPod> {
         let prover = &Prover {};
         let mut builder = MainPodBuilder::new(&self.params, &self.vd_set);
@@ -229,16 +229,16 @@ impl Helper {
             CraftBuilder::new(BuildContext::new(&mut builder, &self.batches), &self.params);
         let st_craft = match recipe {
             Recipe::Stone => {
-                // unwrap safe since if we're at Stone, pow_pod is Some
-                let pow_pod = pow_pod.unwrap();
-                let st_pow = pow_pod.pub_statements()[0].clone();
-                let main_pow_pod = MainPod {
-                    pod: Box::new(pow_pod.clone()),
-                    public_statements: pow_pod.pub_statements(),
+                // unwrap safe since if we're at Stone, vdf_pod is Some
+                let vdf_pod = vdf_pod.unwrap();
+                let st_vdf = vdf_pod.pub_statements()[0].clone();
+                let main_vdf_pod = MainPod {
+                    pod: Box::new(vdf_pod.clone()),
+                    public_statements: vdf_pod.pub_statements(),
                     params: craft_builder.params.clone(),
                 };
-                craft_builder.ctx.builder.add_pod(main_pow_pod);
-                craft_builder.st_is_stone(item_def, st_item_def.clone(), st_pow)?
+                craft_builder.ctx.builder.add_pod(main_vdf_pod);
+                craft_builder.st_is_stone(item_def, st_item_def.clone(), st_vdf)?
             }
             Recipe::Wood => craft_builder.st_is_wood(item_def, st_item_def.clone())?,
             Recipe::Axe => craft_builder.st_is_axe(
@@ -306,7 +306,7 @@ pub fn craft_item(
     let vd_set = DEFAULT_VD_SET.clone();
     let key = rand_raw_value();
     info!("About to craft \"{recipe}\" with key {key:#}");
-    let (item_def, input_items, pow_pod) = match recipe {
+    let (item_def, input_items, vdf_pod) = match recipe {
         Recipe::Stone => {
             if !inputs.is_empty() {
                 bail!("{recipe} takes 0 inputs");
@@ -317,20 +317,20 @@ pub fn craft_item(
                 .unwrap();
 
             let start = std::time::Instant::now();
-            let pow_pod = PowPod::new(
+            let vdf_pod = VdfPod::new(
                 params,
                 vd_set.clone(),
                 3, // num_iters
                 RawValue::from(ingredients_def.dict(params)?.commitment()),
             )?;
-            log::info!("[TIME] PowPod proving time: {:?}", start.elapsed());
+            log::info!("[TIME] VdfPod proving time: {:?}", start.elapsed());
             (
                 ItemDef {
                     ingredients: ingredients_def.clone(),
-                    work: pow_pod.output,
+                    work: vdf_pod.output,
                 },
                 vec![],
-                Some(pow_pod),
+                Some(vdf_pod),
             )
         }
         Recipe::Wood => {
@@ -398,7 +398,7 @@ pub fn craft_item(
 
     let helper = Helper::new(params.clone(), vd_set);
     let input_item_pods: Vec<_> = input_items.iter().map(|item| &item.pod).cloned().collect();
-    let pod = helper.make_item_pod(recipe, item_def.clone(), input_item_pods, pow_pod)?;
+    let pod = helper.make_item_pod(recipe, item_def.clone(), input_item_pods, vdf_pod)?;
 
     let crafted_item = CraftedItem { pod, def: item_def };
     let mut file = std::fs::File::create(output)?;

--- a/app_gui/src/crafting.rs
+++ b/app_gui/src/crafting.rs
@@ -40,13 +40,13 @@ lazy_static! {
         outputs: &["Stone"],
         predicate: r#"
 use intro Vdf(count, input, output) from 0x3493488bc23af15ac5fabe38c3cb6c4b66adb57e3898adf201ae50cc57183f65
-use intro PoW(input, difficulty, hash_output) from 0x8088c0d4f95988793df8a203412f36df4d82cfd98f33a0f4287156eb29f84bd7
+use intro Pow(hash, difficulty) from 0x42fed42704533123de144a9e820c9d6bdf4c8616f29664111469bd696b628686 // powpod vd hash
 
 IsStone(item, private: ingredients, inputs, key, work, difficulty, ingredients_hash) = AND(
     ItemDef(item, ingredients, inputs, key, work)
     Equal(inputs, {})
     DictContains(ingredients, "blueprint", "stone")
-    PoW(ingredients, difficulty, ingredients_hash)
+    Pow(ingredients, difficulty)
     Vdf(3, ingredients, work)
 )"#,
         ..Default::default()
@@ -59,6 +59,7 @@ IsWood(item, private: ingredients, inputs, key, work) = AND(
     ItemDef(item, ingredients, inputs, key, work)
     Equal(inputs, {})
     DictContains(ingredients, "blueprint", "wood")
+    Pow(ingredients, difficulty)
 )"#,
         ..Default::default()
     };
@@ -70,6 +71,7 @@ IsWood(item, private: ingredients, inputs, key, work) = AND(
 IsAxe(item, private: ingredients, inputs, key, work, s1, wood, stone) = AND(
     ItemDef(item, ingredients, inputs, key, work)
     DictContains(ingredients, "blueprint", "axe")
+    Pow(ingredients, difficulty)
     Equal(work, {})
 
     // 2 ingredients

--- a/app_gui/src/crafting.rs
+++ b/app_gui/src/crafting.rs
@@ -40,11 +40,13 @@ lazy_static! {
         outputs: &["Stone"],
         predicate: r#"
 use intro Vdf(count, input, output) from 0x3493488bc23af15ac5fabe38c3cb6c4b66adb57e3898adf201ae50cc57183f65
+use intro PoW(input, difficulty, hash_output) from 0x8088c0d4f95988793df8a203412f36df4d82cfd98f33a0f4287156eb29f84bd7
 
-IsStone(item, private: ingredients, inputs, key, work) = AND(
+IsStone(item, private: ingredients, inputs, key, work, difficulty, ingredients_hash) = AND(
     ItemDef(item, ingredients, inputs, key, work)
     Equal(inputs, {})
     DictContains(ingredients, "blueprint", "stone")
+    PoW(ingredients, difficulty, ingredients_hash)
     Vdf(3, ingredients, work)
 )"#,
         ..Default::default()

--- a/app_gui/src/crafting.rs
+++ b/app_gui/src/crafting.rs
@@ -39,13 +39,13 @@ lazy_static! {
         description: "Stone.  Hard to find.",
         outputs: &["Stone"],
         predicate: r#"
-use intro Pow(count, input, output) from 0x3493488bc23af15ac5fabe38c3cb6c4b66adb57e3898adf201ae50cc57183f65
+use intro Vdf(count, input, output) from 0x3493488bc23af15ac5fabe38c3cb6c4b66adb57e3898adf201ae50cc57183f65
 
 IsStone(item, private: ingredients, inputs, key, work) = AND(
     ItemDef(item, ingredients, inputs, key, work)
     Equal(inputs, {})
     DictContains(ingredients, "blueprint", "stone")
-    Pow(3, ingredients, work)
+    Vdf(3, ingredients, work)
 )"#,
         ..Default::default()
     };
@@ -136,7 +136,7 @@ IsTomato(item, private: batch, ingredients, inputs, key, work, farm_level) = AND
     TomatoRecipe(batch, farm_level, ingredients, inputs, key, work)
     ItemInBatch(item, batch, "tomato")
 )
-    
+
 UsedFarm(item, level, private: batch, ingredients, inputs, key, work) = AND(
     TomatoRecipe(batch, level ingredients, inputs, key, work)
     ItemInBatch(item, batch, "farm")
@@ -164,7 +164,7 @@ SteelSwordRecipe(batch, ingredients, inputs, key, work, forge, steel1, steel2, w
     SetInsert(s3, s2, steel2)
     SetInsert(s4, s3, wood)
     SetInsert(inputs, s4, forge)
-    
+
     IsForge(forge)
     IsSteel(steel1)
     IsSteel(steel2)
@@ -215,7 +215,7 @@ IsH(item) = OR(
     IsH0(item)
     IsH1(item)
 )
-    
+
 IsO(item, private: batch, ingredients, inputs, key, work) = AND(
     DisassembleH2O(batch, ingredients, inputs, key, work)
     ItemInBatch(item, batch, "2")
@@ -233,7 +233,7 @@ IsRefinedUranium(item, private: ingredients, inputs, key, work) = AND(
 
     SetInsert(inputs, {}, uranium)
     IsUranium(uranium)
-    Pow(100, ingredients, work)
+    Vdf(100, ingredients, work)
 )"#,
         ..Default::default()
     };

--- a/craftlib/src/constants.rs
+++ b/craftlib/src/constants.rs
@@ -5,7 +5,7 @@ pub const STONE_MINING_MAX: u64 = 0x0020_0000_0000_0000;
 pub const STONE_WORK: RawValue = EMPTY_VALUE;
 
 pub const WOOD_BLUEPRINT: &str = "wood";
-pub const WOOD_MINING_MAX: u64 = 0x0010_0000_0000_0000;
+pub const WOOD_MINING_MAX: u64 = 0x0020_0000_0000_0000;
 pub const WOOD_WORK: RawValue = EMPTY_VALUE;
 
 pub const AXE_BLUEPRINT: &str = "axe";

--- a/craftlib/src/constants.rs
+++ b/craftlib/src/constants.rs
@@ -5,7 +5,7 @@ pub const STONE_MINING_MAX: u64 = 0x0020_0000_0000_0000;
 pub const STONE_WORK: RawValue = EMPTY_VALUE;
 
 pub const WOOD_BLUEPRINT: &str = "wood";
-pub const WOOD_MINING_MAX: u64 = 0x0020_0000_0000_0000;
+pub const WOOD_MINING_MAX: u64 = 0x0010_0000_0000_0000;
 pub const WOOD_WORK: RawValue = EMPTY_VALUE;
 
 pub const AXE_BLUEPRINT: &str = "axe";

--- a/craftlib/src/item.rs
+++ b/craftlib/src/item.rs
@@ -91,6 +91,7 @@ impl<'a> CraftBuilder<'a> {
         &mut self,
         item_def: ItemDef,
         st_item_def: Statement,
+        st_pow: Statement,
     ) -> anyhow::Result<Statement> {
         // Build IsWood(item)
         Ok(st_custom!(self.ctx,
@@ -98,6 +99,7 @@ impl<'a> CraftBuilder<'a> {
                 st_item_def,
                 Equal(item_def.ingredients.inputs_set(self.params)?, EMPTY_VALUE),
                 DictContains(item_def.ingredients.dict(self.params)?, "blueprint", WOOD_BLUEPRINT),
+                st_pow,
                 Equal(item_def.work, EMPTY_VALUE)
             ))?)
     }

--- a/craftlib/src/item.rs
+++ b/craftlib/src/item.rs
@@ -75,6 +75,7 @@ impl<'a> CraftBuilder<'a> {
         &mut self,
         item_def: ItemDef,
         st_item_def: Statement,
+        st_pow: Statement,
         st_vdf: Statement,
     ) -> anyhow::Result<Statement> {
         // Build IsStone(item)
@@ -83,6 +84,7 @@ impl<'a> CraftBuilder<'a> {
                 st_item_def,
                 Equal(item_def.ingredients.inputs_set(self.params)?, EMPTY_VALUE),
                 DictContains(item_def.ingredients.dict(self.params)?, "blueprint", STONE_BLUEPRINT),
+                st_pow,
                 st_vdf
             ))?)
     }
@@ -129,6 +131,7 @@ impl<'a> CraftBuilder<'a> {
         &mut self,
         item_def: ItemDef,
         st_item_def: Statement,
+        st_pow: Statement,
         st_is_wood: Statement,
         st_is_stone: Statement,
     ) -> anyhow::Result<Statement> {
@@ -138,6 +141,7 @@ impl<'a> CraftBuilder<'a> {
             IsAxe() = (
                 st_item_def,
                 DictContains(item_def.ingredients.dict(self.params)?, "blueprint", AXE_BLUEPRINT),
+                st_pow,
                 Equal(item_def.work, EMPTY_VALUE),
                 st_axe_inputs
             ))?)

--- a/craftlib/src/item.rs
+++ b/craftlib/src/item.rs
@@ -36,12 +36,13 @@ impl MiningRecipe {
         mine_max: u64,
     ) -> pod2::middleware::Result<Option<IngredientsDef>> {
         log::info!("Mining...");
+        let start = std::time::Instant::now();
         for seed in start_seed..=i64::MAX {
             let ingredients = self.prep_ingredients(key, seed);
             let ingredients_hash = ingredients.hash(params)?;
             let mining_val = ingredients_hash.to_fields(params)[0];
             if mining_val.0 <= mine_max {
-                log::info!("Mining complete!");
+                log::info!("Mining complete! Time taken: {:?}", start.elapsed());
                 return Ok(Some(ingredients));
             }
         }

--- a/craftlib/src/lib.rs
+++ b/craftlib/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod constants;
 pub mod item;
-pub mod powpod;
+pub mod vdfpod;
 pub mod predicates;
 mod test_util;

--- a/craftlib/src/lib.rs
+++ b/craftlib/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod constants;
 pub mod item;
 pub mod vdfpod;
+pub mod powpod;
 pub mod predicates;
 mod test_util;

--- a/craftlib/src/powpod.rs
+++ b/craftlib/src/powpod.rs
@@ -1,0 +1,469 @@
+//! PoWPod: Introduction Pod that proves Proof of Work (mining difficulty).
+//! - takes as input a hash value and a difficulty target
+//! - proves that hash[0] <= difficulty_target
+//!
+//! This is used to prove that mining work was done to find a valid nonce/seed.
+//!
+//! Circuit structure:
+//! 1. PoWCircuit:
+//!     - hash: RawValue (4 field elements - already a hash/commitment)
+//!     - difficulty_target: u64 constant
+//!     - proves: hash[0] <= difficulty_target
+//!
+//! 2. PoWPod:
+//!     - satisfies the pod2's Pod trait interface
+//!     - verifies the proof from PoWCircuit
+//!
+//! Usage:
+//! ```rust
+//!   use pod2::{backends::plonky2::basetypes::DEFAULT_VD_SET, middleware::{Params, RawValue}};
+//!   use craftlib::powpod::PoWPod;
+//!
+//!   let params = Params::default();
+//!   let vd_set = &*DEFAULT_VD_SET;
+//!   let hash = RawValue::from(...); // ingredients commitment/hash
+//!   let difficulty = 0x0020_0000_0000_0000u64;
+//!   let pow_pod = PoWPod::new(&params, vd_set.clone(), hash, difficulty).unwrap();
+//! ```
+
+use anyhow::Result;
+use itertools::Itertools;
+use plonky2::{
+    field::types::Field,
+    hash::hash_types::{HashOut, HashOutTarget},
+    iop::{
+        target::Target,
+        witness::{PartialWitness, WitnessWrite},
+    },
+    plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitData, VerifierOnlyCircuitData},
+        proof::ProofWithPublicInputs,
+    },
+};
+use pod2::{
+    backends::plonky2::{
+        Error, Result as BResult,
+        circuits::{
+            common::{
+                CircuitBuilderPod, PredicateTarget, StatementArgTarget, StatementTarget,
+                ValueTarget,
+            },
+            mainpod::calculate_statements_hash_circuit,
+        },
+        deserialize_proof, mainpod,
+        mainpod::calculate_statements_hash,
+        serialize_proof,
+    },
+    measure_gates_begin, measure_gates_end, middleware,
+    middleware::{
+        C, D, EMPTY_HASH, F, Hash, IntroPredicateRef, Params, Pod, Proof, RawValue,
+        ToFields, VDSet,
+    },
+    timed,
+};
+use serde::{Deserialize, Serialize};
+
+const POW_POD_TYPE: (usize, &str) = (2002, "PoW");
+
+static STANDARD_POW_POD_DATA: std::sync::LazyLock<(PoWPodTarget, CircuitData<F, C, D>)> =
+    std::sync::LazyLock::new(|| build().expect("successful build"));
+
+fn build() -> Result<(PoWPodTarget, CircuitData<F, C, D>)> {
+    let params = Params::default();
+
+    let rec_circuit_data =
+        &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data();
+
+    let common_data = rec_circuit_data.0.clone();
+    let config = common_data.config.clone();
+
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let pow_pod_target = PoWPodTarget::add_targets(&mut builder, &params)?;
+    pod2::backends::plonky2::recursion::pad_circuit(&mut builder, &common_data);
+
+    let data = timed!("PoWPod build", builder.build::<C>());
+    assert_eq!(common_data, data.common);
+    Ok((pow_pod_target, data))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PoWPod {
+    pub params: Params,
+    pub hash: RawValue,  // The hash to check (e.g., dict commitment)
+    pub difficulty: F,  // difficulty target as a field element
+
+    pub vd_set: VDSet,
+    pub statements_hash: Hash,
+    pub proof: Proof,
+
+    pub common_hash: String,
+}
+
+#[allow(dead_code)]
+impl PoWPod {
+    /// Creates a PoWPod proving that hash[0] <= difficulty
+    pub fn new(
+        params: &Params,
+        vd_set: VDSet,
+        hash: RawValue,
+        difficulty: u64,
+    ) -> Result<PoWPod> {
+        // Pre-check difficulty (optional, for early bail)
+        if hash.0[0].0 > difficulty {
+            anyhow::bail!("Hash does not meet difficulty requirement");
+        }
+
+        let difficulty_f = F::from_canonical_u64(difficulty);
+
+        // Build the proof
+        let (pow_pod_target, circuit_data) = &*STANDARD_POW_POD_DATA;
+        let statements = pub_self_statements(hash, difficulty_f)
+            .into_iter()
+            .map(mainpod::Statement::from)
+            .collect_vec();
+        let statements_hash: Hash = calculate_statements_hash(&statements, params);
+
+        let pow_input = PoWPodInput {
+            vd_root: vd_set.root(),
+            statements_hash,
+            hash,
+            difficulty: difficulty_f,
+        };
+
+        let mut pw = PartialWitness::<F>::new();
+        pow_pod_target.set_targets(&mut pw, &pow_input)?;
+        
+        let proof_with_pis = timed!(
+            "prove PoW difficulty check",
+            circuit_data.prove(pw)?
+        );
+
+        circuit_data
+            .verifier_data()
+            .verify(proof_with_pis.clone())?;
+
+        let common_hash: String =
+            pod2::backends::plonky2::mainpod::cache_get_rec_main_pod_common_hash(params).clone();
+
+        Ok(PoWPod {
+            params: params.clone(),
+            statements_hash,
+            hash,
+            difficulty: difficulty_f,
+            proof: proof_with_pis.proof,
+            vd_set: vd_set.clone(),
+            common_hash,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Data {
+    hash: RawValue,
+    difficulty: F,
+    proof: String,
+    common_hash: String,
+}
+
+impl Pod for PoWPod {
+    fn params(&self) -> &Params {
+        &self.params
+    }
+
+    fn verify(&self) -> pod2::backends::plonky2::Result<()> {
+        let statements = pub_self_statements(self.hash, self.difficulty)
+            .into_iter()
+            .map(mainpod::Statement::from)
+            .collect_vec();
+        let statements_hash: Hash = calculate_statements_hash(&statements, &self.params);
+        if statements_hash != self.statements_hash {
+            return Err(Error::statements_hash_not_equal(
+                self.statements_hash,
+                statements_hash,
+            ));
+        }
+
+        let (_, circuit_data) = &*STANDARD_POW_POD_DATA;
+
+        let public_inputs = statements_hash
+            .to_fields(&self.params)
+            .iter()
+            .chain(self.vd_set().root().0.iter())
+            .cloned()
+            .collect_vec();
+
+        circuit_data
+            .verify(ProofWithPublicInputs {
+                proof: self.proof.clone(),
+                public_inputs,
+            })
+            .map_err(|e| Error::custom(format!("PoWPod proof verification failure: {e:?}")))
+    }
+
+    fn statements_hash(&self) -> Hash {
+        self.statements_hash
+    }
+
+    fn pod_type(&self) -> (usize, &'static str) {
+        POW_POD_TYPE
+    }
+
+    fn pub_self_statements(&self) -> Vec<middleware::Statement> {
+        pub_self_statements(self.hash, self.difficulty)
+    }
+
+    fn serialize_data(&self) -> serde_json::Value {
+        serde_json::to_value(Data {
+            hash: self.hash,
+            difficulty: self.difficulty,
+            proof: serialize_proof(&self.proof),
+            common_hash: self.common_hash.clone(),
+        })
+        .expect("serialization to json")
+    }
+
+    fn deserialize_data(
+        params: Params,
+        data: serde_json::Value,
+        vd_set: VDSet,
+        statements_hash: Hash,
+    ) -> BResult<Self> {
+        let data: Data = serde_json::from_value(data)?;
+        let common =
+            &*pod2::backends::plonky2::cache_get_standard_rec_main_pod_common_circuit_data();
+        let proof = deserialize_proof(common, &data.proof)?;
+        Ok(Self {
+            params,
+            hash: data.hash,
+            difficulty: data.difficulty,
+            vd_set,
+            statements_hash,
+            proof,
+            common_hash: data.common_hash,
+        })
+    }
+
+    fn verifier_data(&self) -> VerifierOnlyCircuitData<C, D> {
+        STANDARD_POW_POD_DATA
+            .1
+            .verifier_data()
+            .verifier_only
+            .clone()
+    }
+
+    fn common_hash(&self) -> String {
+        self.common_hash.clone()
+    }
+
+    fn proof(&self) -> Proof {
+        self.proof.clone()
+    }
+
+    fn vd_set(&self) -> &VDSet {
+        &self.vd_set
+    }
+}
+
+fn pub_self_statements(hash: RawValue, difficulty: F) -> Vec<middleware::Statement> {
+    vec![middleware::Statement::Intro(
+        IntroPredicateRef {
+            name: POW_POD_TYPE.1.to_string(),
+            args_len: 2,
+            verifier_data_hash: EMPTY_HASH,
+        },
+        vec![
+            hash.into(),
+            RawValue([difficulty, F::ZERO, F::ZERO, F::ZERO]).into(),
+        ],
+    )]
+}
+
+fn pub_self_statements_target(
+    builder: &mut CircuitBuilder<F, D>,
+    params: &Params,
+    hash: &[Target],
+    difficulty: Target,
+) -> Vec<StatementTarget> {
+    let zero = builder.zero();
+    let st_arg_0 = StatementArgTarget::literal(builder, &ValueTarget::from_slice(hash));
+    let st_arg_1 = StatementArgTarget::literal(
+        builder,
+        &ValueTarget::from_slice(&[difficulty, zero, zero, zero]),
+    );
+    
+    let args = [st_arg_0, st_arg_1]
+        .into_iter()
+        .chain(core::iter::repeat_with(|| {
+            StatementArgTarget::none(builder)
+        }))
+        .take(params.max_statement_args)
+        .collect();
+
+    let verifier_data_hash = builder.constant_hash(HashOut {
+        elements: EMPTY_HASH.0,
+    });
+    let predicate = PredicateTarget::new_intro(builder, verifier_data_hash);
+    vec![StatementTarget { predicate, args }]
+}
+
+#[derive(Clone, Debug)]
+struct PoWPodTarget {
+    vd_root: HashOutTarget,
+    statements_hash: HashOutTarget,
+    hash: ValueTarget,
+    difficulty: Target,
+}
+
+struct PoWPodInput {
+    vd_root: Hash,
+    statements_hash: Hash,
+    hash: RawValue,
+    difficulty: F,
+}
+
+impl PoWPodTarget {
+    fn add_targets(builder: &mut CircuitBuilder<F, D>, params: &Params) -> Result<Self> {
+        let measure = measure_gates_begin!(builder, "PoWPodTarget");
+
+        // Add virtual inputs
+        let hash = builder.add_virtual_value();
+        let difficulty = builder.add_virtual_target();
+
+        // Check that hash[0] <= difficulty IN-CIRCUIT
+        // We need to prove hash[0] <= difficulty in a way that handles field arithmetic
+        
+        let hash_first = hash.elements[0];
+        
+        // Strategy: Prove that difficulty - hash_first is non-negative in u64 space
+        // 1. Compute diff = difficulty - hash_first (in field arithmetic)
+        // 2. Split both into low/high 32-bit limbs to ensure they're valid u64s
+        // 3. Prove the subtraction is valid in u64 space (no underflow)
+        
+        // Split hash_first into two 32-bit limbs: hash_lo + hash_hi * 2^32
+        let hash_bits = builder.split_le(hash_first, 64);
+        let hash_lo_bits = &hash_bits[0..32];
+        let hash_hi_bits = &hash_bits[32..64];
+        
+        // Reconstruct to verify decomposition
+        let two_32 = builder.constant(F::from_canonical_u64(1u64 << 32));
+        let hash_lo = builder.le_sum(hash_lo_bits.iter().copied());
+        let hash_hi = builder.le_sum(hash_hi_bits.iter().copied());
+        let hash_reconstructed = builder.mul_add(hash_hi, two_32, hash_lo);
+        builder.connect(hash_first, hash_reconstructed);
+        
+        // Split difficulty into two 32-bit limbs: diff_lo + diff_hi * 2^32  
+        let diff_bits = builder.split_le(difficulty, 64);
+        let diff_lo_bits = &diff_bits[0..32];
+        let diff_hi_bits = &diff_bits[32..64];
+        
+        let diff_lo = builder.le_sum(diff_lo_bits.iter().copied());
+        let diff_hi = builder.le_sum(diff_hi_bits.iter().copied());
+        let diff_reconstructed = builder.mul_add(diff_hi, two_32, diff_lo);
+        builder.connect(difficulty, diff_reconstructed);
+        
+        // Prove difficulty >= hash_first in-circuit
+        // Strategy: Show that (difficulty - hash_first) fits in 64 bits
+        // If hash_first > difficulty, the difference would be negative,
+        // which wraps to a huge number (> 2^64) and split_le will fail
+        let diff_full = builder.sub(difficulty, hash_first);
+        let _diff_bits = builder.split_le(diff_full, 64);
+
+        // Calculate statements_hash
+        let statements = pub_self_statements_target(
+            builder,
+            params,
+            &hash.elements,
+            difficulty,
+        );
+        let statements_hash = calculate_statements_hash_circuit(params, builder, &statements);
+
+        // Register public inputs
+        let vd_root = builder.add_virtual_hash();
+        builder.register_public_inputs(&statements_hash.elements);
+        builder.register_public_inputs(&vd_root.elements);
+
+        measure_gates_end!(builder, measure);
+        
+        Ok(PoWPodTarget {
+            vd_root,
+            statements_hash,
+            hash,
+            difficulty,
+        })
+    }
+
+    fn set_targets(&self, pw: &mut PartialWitness<F>, input: &PoWPodInput) -> Result<()> {
+        pw.set_target_arr(&self.hash.elements, &input.hash.0)?;
+        pw.set_target(self.difficulty, input.difficulty)?;
+        pw.set_hash_target(
+            self.statements_hash,
+            HashOut::from_vec(input.statements_hash.0.to_vec()),
+        )?;
+        pw.set_target_arr(&self.vd_root.elements, &input.vd_root.0)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pod2::{
+        backends::plonky2::basetypes::DEFAULT_VD_SET,
+        middleware::hash_str,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_pow_pod() -> Result<()> {
+        let params = Params::default();
+        let vd_set = &*DEFAULT_VD_SET;
+
+        // Find a valid input by brute force (for testing)
+        let difficulty = 0x0020_0000_0000_0000u64;
+        let mut found_input = None;
+        
+        for i in 0..10000 {
+            let test_input = RawValue::from(i as i64);
+            let hash_output = RawValue::from(pod2::middleware::hash_value(&test_input));
+            if hash_output.0[0].0 <= difficulty {
+                found_input = Some(test_input);
+                println!("Found valid input at i={}: hash={:#x}", i, hash_output.0[0].0);
+                break;
+            }
+        }
+        
+        let ingredients = found_input.expect("Should find valid input");
+
+        // This should succeed
+        let pow_pod = PoWPod::new(&params, vd_set.clone(), ingredients, difficulty)?;
+        pow_pod.verify()?;
+
+        println!(
+            "pow_pod.verifier_data_hash(): {:#} . To be used in predicates.",
+            pow_pod.verifier_data_hash()
+        );
+
+        // Verify hash is computed correctly and meets difficulty
+        let hash_output = RawValue::from(pod2::middleware::hash_value(&ingredients));
+        assert!(hash_output.0[0].0 <= difficulty);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_pow_pod_fails_above_difficulty() -> Result<()> {
+        let params = Params::default();
+        let vd_set = &*DEFAULT_VD_SET;
+
+        let input = RawValue::from(hash_str("definitely above difficulty"));
+        let difficulty = 1u64; // Very strict difficulty
+
+        // This should fail
+        let result = PoWPod::new(&params, vd_set.clone(), input, difficulty);
+        assert!(result.is_err());
+
+        Ok(())
+    }
+}

--- a/craftlib/src/predicates.rs
+++ b/craftlib/src/predicates.rs
@@ -5,7 +5,16 @@ use plonky2::field::types::Field;
 use pod2::middleware::{CustomPredicateRef, F, Params};
 use pod2utils::PredicateDefs;
 
-use crate::constants::WOOD_MINING_MAX;
+use crate::constants::{AXE_MINING_MAX, STONE_MINING_MAX, WOOD_MINING_MAX};
+
+/// Convert a u64 difficulty to RawValue format for use in predicates (little-endian)
+fn difficulty_to_raw_string(difficulty: u64) -> String {
+    let difficulty_f = F::from_canonical_u64(difficulty);
+    format!(
+        "Raw(0x{:016x}{:016x}{:016x}{:016x})",
+        0u64, 0u64, 0u64, difficulty_f.0
+    )
+}
 
 pub struct ItemPredicates {
     pub defs: PredicateDefs,
@@ -21,25 +30,27 @@ impl ItemPredicates {
         // 8 arguments per predicate, at most 5 of which are public
         // 5 statements per predicate
 
-        // Convert WOOD_MINING_MAX to RawValue format for predicate (little-endian)
-        let wood_difficulty_f = F::from_canonical_u64(WOOD_MINING_MAX);
-        let wood_difficulty_raw = format!(
-            "Raw(0x{:016x}{:016x}{:016x}{:016x})",
-            0u64, 0u64, 0u64, wood_difficulty_f.0
-        );
+        // Convert mining difficulties to RawValue format for predicates
+        let stone_difficulty_raw = difficulty_to_raw_string(STONE_MINING_MAX);
+        let wood_difficulty_raw = difficulty_to_raw_string(WOOD_MINING_MAX);
+        let axe_difficulty_raw = difficulty_to_raw_string(AXE_MINING_MAX);
 
-        let batch_def_1 = r#"
+        let batch_def_1 = format!(
+            r#"
             use intro Vdf(count, input, output) from 0x3493488bc23af15ac5fabe38c3cb6c4b66adb57e3898adf201ae50cc57183f65 // vdfpod vd hash
             use intro PoW(hash, difficulty) from 0x42fed42704533123de144a9e820c9d6bdf4c8616f29664111469bd696b628686 // powpod vd hash
 
-            // Example of a mined item with no inputs or sequential work.
-            // Stone requires working in a stone mine (blueprint="stone") and
-            // 10 leading 0s.
+            // Example of a mined item with mining difficulty check and VDF work.
+            // Stone requires:
+            // - blueprint="stone"
+            // - hash(ingredients) meets difficulty (PoW mining)
+            // - sequential work via VDF
             IsStone(item, private: ingredients, inputs, key, work) = AND(
                 ItemDef(item, ingredients, inputs, key, work)
-                Equal(inputs, {})
+                Equal(inputs, {{}})
                 DictContains(ingredients, "blueprint", "stone")
-                Vdf(3, ingredients, work)
+                PoW(ingredients, {stone_difficulty_raw})  // Proves ingredients <= STONE_MINING_MAX
+                Vdf(3, ingredients, work)  // Proves 3 iterations of sequential hashing
             )
 
             // Example of a mined item with just PoW (no VDF work).
@@ -48,17 +59,21 @@ impl ItemPredicates {
             // - hash(ingredients) meets difficulty (PoW mining)
             IsWood(item, private: ingredients, inputs, key, work) = AND(
                 ItemDef(item, ingredients, inputs, key, work)
-                Equal(inputs, {})
+                Equal(inputs, {{}})
                 DictContains(ingredients, "blueprint", "wood")
-                PoW(ingredients, "#.to_string() + &wood_difficulty_raw + r#")  // Proves ingredients <= WOOD_MINING_MAX
-                Equal(work, {})  // No VDF work required
+                PoW(ingredients, {wood_difficulty_raw})  // Proves ingredients <= WOOD_MINING_MAX
+                Equal(work, {{}})  // No VDF work required
             )
-            "#;
+            "#
+        );
 
-        let batch_def_2 = r#"
+        let batch_def_2 = format!(
+            r#"
+            use intro PoW(hash, difficulty) from 0x42fed42704533123de144a9e820c9d6bdf4c8616f29664111469bd696b628686 // powpod vd hash
+
             AxeInputs(inputs, private: s1, wood, stone) = AND(
                 // 2 ingredients
-                SetInsert(s1, {}, wood)
+                SetInsert(s1, {{}}, wood)
                 SetInsert(inputs, s1, stone)
 
                 // prove the ingredients are correct.
@@ -66,12 +81,12 @@ impl ItemPredicates {
                 IsStone(stone)
             )
 
-            // Combining Stone and Wood to get Axe is easy (no sequential work).
-            // TODO: Require a smelter as a tool
+            // Combining Stone and Wood to get Axe requires mining (no sequential work).
             IsAxe(item, private: ingredients, inputs, key, work) = AND(
                 ItemDef(item, ingredients, inputs, key, work)
                 DictContains(ingredients, "blueprint", "axe")
-                Equal(work, {})
+                PoW(ingredients, {axe_difficulty_raw})  // Proves ingredients <= AXE_MINING_MAX
+                Equal(work, {{}})
 
                 AxeInputs(inputs)
             )
@@ -79,7 +94,7 @@ impl ItemPredicates {
             // Wooden Axe:
             WoodenAxeInputs(inputs, private: s1, wood1, wood2) = AND(
                 // 2 ingredients
-                SetInsert(s1, {}, wood1)
+                SetInsert(s1, {{}}, wood1)
                 SetInsert(inputs, s1, wood2)
 
                 // prove the ingredients are correct.
@@ -91,13 +106,14 @@ impl ItemPredicates {
             IsWoodenAxe(item, private: ingredients, inputs, key, work) = AND(
                 ItemDef(item, ingredients, inputs, key, work)
                 DictContains(ingredients, "blueprint", "wooden-axe")
-                Equal(work, {})
+                Equal(work, {{}})
 
                 WoodenAxeInputs(inputs)
             )
-            "#;
+            "#
+        );
 
-        let batch_defs = [batch_def_1, batch_def_2.to_string()];
+        let batch_defs = [batch_def_1, batch_def_2];
         let batch_defs_refs: Vec<&str> = batch_defs.iter().map(|s| s.as_str()).collect();
         let defs = PredicateDefs::new(
             params,

--- a/craftlib/src/predicates.rs
+++ b/craftlib/src/predicates.rs
@@ -38,30 +38,30 @@ impl ItemPredicates {
         let batch_def_1 = format!(
             r#"
             use intro Vdf(count, input, output) from 0x3493488bc23af15ac5fabe38c3cb6c4b66adb57e3898adf201ae50cc57183f65 // vdfpod vd hash
-            use intro PoW(hash, difficulty) from 0x42fed42704533123de144a9e820c9d6bdf4c8616f29664111469bd696b628686 // powpod vd hash
+            use intro Pow(hash, difficulty) from 0x42fed42704533123de144a9e820c9d6bdf4c8616f29664111469bd696b628686 // powpod vd hash
 
             // Example of a mined item with mining difficulty check and VDF work.
             // Stone requires:
             // - blueprint="stone"
-            // - hash(ingredients) meets difficulty (PoW mining)
+            // - hash(ingredients) meets difficulty (Pow mining)
             // - sequential work via VDF
             IsStone(item, private: ingredients, inputs, key, work) = AND(
                 ItemDef(item, ingredients, inputs, key, work)
                 Equal(inputs, {{}})
                 DictContains(ingredients, "blueprint", "stone")
-                PoW(ingredients, {stone_difficulty_raw})  // Proves ingredients <= STONE_MINING_MAX
+                Pow(ingredients, {stone_difficulty_raw})  // Proves ingredients <= STONE_MINING_MAX
                 Vdf(3, ingredients, work)  // Proves 3 iterations of sequential hashing
             )
 
-            // Example of a mined item with just PoW (no VDF work).
+            // Example of a mined item with just Pow (no VDF work).
             // Wood requires:
             // - blueprint="wood"
-            // - hash(ingredients) meets difficulty (PoW mining)
+            // - hash(ingredients) meets difficulty (Pow mining)
             IsWood(item, private: ingredients, inputs, key, work) = AND(
                 ItemDef(item, ingredients, inputs, key, work)
                 Equal(inputs, {{}})
                 DictContains(ingredients, "blueprint", "wood")
-                PoW(ingredients, {wood_difficulty_raw})  // Proves ingredients <= WOOD_MINING_MAX
+                Pow(ingredients, {wood_difficulty_raw})  // Proves ingredients <= WOOD_MINING_MAX
                 Equal(work, {{}})  // No VDF work required
             )
             "#
@@ -69,7 +69,7 @@ impl ItemPredicates {
 
         let batch_def_2 = format!(
             r#"
-            use intro PoW(hash, difficulty) from 0x42fed42704533123de144a9e820c9d6bdf4c8616f29664111469bd696b628686 // powpod vd hash
+            use intro Pow(hash, difficulty) from 0x42fed42704533123de144a9e820c9d6bdf4c8616f29664111469bd696b628686 // powpod vd hash
 
             AxeInputs(inputs, private: s1, wood, stone) = AND(
                 // 2 ingredients
@@ -85,7 +85,7 @@ impl ItemPredicates {
             IsAxe(item, private: ingredients, inputs, key, work) = AND(
                 ItemDef(item, ingredients, inputs, key, work)
                 DictContains(ingredients, "blueprint", "axe")
-                PoW(ingredients, {axe_difficulty_raw})  // Proves ingredients <= AXE_MINING_MAX
+                Pow(ingredients, {axe_difficulty_raw})  // Proves ingredients <= AXE_MINING_MAX
                 Equal(work, {{}})
 
                 AxeInputs(inputs)


### PR DESCRIPTION
The current `powpod` is actually a `vdfpod` since it cannot be parallelized and is doing recursive proofs. This PR adds a new `powpod` that checks the difficulty of a hash, essentially verifying proof of work. Wood, stone and axe are updated to require it as a statement vs previously a hash was mined but not required in the predicate.